### PR TITLE
Allow a person entity to be used as an origin.

### DIFF
--- a/google_geocode.py
+++ b/google_geocode.py
@@ -58,7 +58,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         cv.time_period,
 })
 
-TRACKABLE_DOMAINS = ['device_tracker', 'sensor']
+TRACKABLE_DOMAINS = ['device_tracker', 'sensor', 'person']
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the sensor platform."""


### PR DESCRIPTION
Simple lets the person domain be used since it supports lat and long like the device_tracker.  Is a fix for #20.