### PR TITLE
Added mandatory "version": "2019.05.02"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/michaelmcarthur/GoogleGeocode-HASS",
   "dependencies": [],
   "codeowners": [],
-  "requirements": []
+  "requirements": [],
   "version": "2019.05.02"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -5,4 +5,5 @@
   "dependencies": [],
   "codeowners": [],
   "requirements": []
+  "version": "2019.05.02"
 }


### PR DESCRIPTION
Now required as mandatory: https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions